### PR TITLE
fix reinstall break

### DIFF
--- a/tests/functional/test_reinstall.py
+++ b/tests/functional/test_reinstall.py
@@ -38,7 +38,7 @@ from cylc.flow.hostuserutil import get_host
 from cylc.flow.pathutil import get_workflow_run_dir
 from cylc.rose.utilities import (
     ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING as ROHIOS)
-from cylc.flow.workflow_files import reinstall_workflow
+from cylc.flow.install import reinstall_workflow
 
 
 HOST = get_host()


### PR DESCRIPTION
Fix one of two breakages in https://github.com/cylc/cylc-rose/pull/219

The simple fix for the simple problem of an interface changing in Cylc:

Tested locally with


| repo | version |
| --- | --- |
| Cylc-flow | 8.2.0 |
| Rose | 2.1.0 |
| Cylc Rose | 1.3.0 |